### PR TITLE
refactor(setup): remove temporary route enumerator for debugging 404 …

### DIFF
--- a/dineq-backend/internal/interfaces/http/routers/setup.go
+++ b/dineq-backend/internal/interfaces/http/routers/setup.go
@@ -2,7 +2,6 @@ package routers
 
 import (
 	"net/http"
-	"sort"
 	"time"
 
 	"github.com/RealEskalate/G6-MenuMate/internal/bootstrap"
@@ -50,81 +49,8 @@ func Setup(env *bootstrap.Env, timeout time.Duration, db mongo.Database, router 
 		NewUploadRoutes(env, api)
 		NewItemRoutes(env, api, db, notifySvc)
 		NewReviewRoutes(env, api, db)
-
-		// Temporary route enumerator for debugging 404 issue on nested review route
-		api.GET("/_routes", func(c *gin.Context) {
-			// gin doesn't expose a public route listing; walking router trees manually avoided for brevity.
-			// Instead, maintain a static slice mirroring registered routes (quick instrumentation approach).
-			routes := []string{
-				"POST /api/v1/auth/register",
-				"POST /api/v1/auth/login",
-				"POST /api/v1/auth/logout",
-				"POST /api/v1/auth/forgot-password",
-				"POST /api/v1/auth/verify-reset-token",
-				"POST /api/v1/auth/reset-password",
-				"POST /api/v1/auth/refresh",
-				"GET /api/v1/auth/google/login",
-				"GET /api/v1/auth/google/callback",
-				"POST /api/v1/auth/verify-email",
-				"POST /api/v1/auth/resend-otp",
-				"PATCH /api/v1/auth/verify-otp",
-				"PATCH /api/v1/users/update-profile",
-				"PATCH /api/v1/users/change-password",
-				"GET /api/v1/me",
-				"GET /api/v1/users/:id",
-				"GET /api/v1/users/avatar-options",
-				"POST /api/v1/ocr/upload",
-				"GET /api/v1/ocr/:id",
-				"DELETE /api/v1/ocr/:id",
-				"POST /api/v1/ocr/:id/retry",
-				"POST /api/v1/notifications/",
-				"GET /api/v1/notifications/:userId",
-				"PUT /api/v1/notifications/:userId/read",
-				"GET /api/v1/notifications/ws",
-				"GET /api/v1/restaurants",
-				"GET /api/v1/restaurants/search",
-				"GET /api/v1/restaurants/:slug",
-				"GET /api/v1/restaurants/nearby",
-				"POST /api/v1/restaurants",
-				"GET /api/v1/restaurants/me",
-				"PATCH /api/v1/restaurants/:slug",
-				"DELETE /api/v1/restaurants/:id",
-				"GET /api/v1/images/search",
-				"POST /api/v1/items/:item_id/reaction",
-				"GET /api/v1/items/:item_id/reaction",
-				"GET /api/v1/menus/:restaurant_slug",
-				"GET /api/v1/menus/:restaurant_slug/:id",
-				"POST /api/v1/menus/:restaurant_slug",
-				"PATCH /api/v1/menus/:restaurant_slug/:id",
-				"DELETE /api/v1/menus/:restaurant_slug/:id",
-				"POST /api/v1/menus/:restaurant_slug/qrcode/:id",
-				"POST /api/v1/menus/:restaurant_slug/publish/:id",
-				"GET /api/v1/qr-code/:restaurant_slug",
-				"PATCH /api/v1/qr-code/:restaurant_slug/:status",
-				"DELETE /api/v1/qr-code/:restaurant_slug",
-				"POST /api/v1/uploads/logo",
-				"POST /api/v1/uploads/image",
-				"GET /api/v1/menu-items/:menu_slug",
-				"POST /api/v1/menu-items/:menu_slug/",
-				"PATCH /api/v1/menu-items/:menu_slug/:id",
-				"GET /api/v1/menu-items/:menu_slug/:id",
-				"POST /api/v1/menu-items/:menu_slug/:id/reviews",
-				"DELETE /api/v1/menu-items/:menu_slug/:id",
-				"POST /api/v1/restaurants/:restaurant_id/items/:item_id/reviews",  // EXPECTED NEW ROUTE
-				"POST /api/v1/restaurants/:restaurant_id/items/:item_id/reviews/", // trailing variant
-				"POST /api/v1/reviews",                                            // legacy
-				"PATCH /api/v1/reviews/:id",
-				"DELETE /api/v1/reviews/:id",
-				"GET /api/v1/reviews/:id",
-				"GET /api/v1/items/:item_id/reviews",
-				"GET /api/v1/items/:item_id/average-rating",
-				"GET /api/v1/restaurants/v/:restaurant_id/average-rating",
-				"GET /api/v1/health",
-			}
-			sort.Strings(routes)
-			c.JSON(200, gin.H{"routes": routes})
-		})
 		h := handler.NewHealthHandler(db, 2*time.Second)
 		api.GET("/health", h.Health)
 	}
 }
+


### PR DESCRIPTION
This pull request removes a temporary debugging route from the API router setup in `setup.go`. The route (`GET /api/v1/_routes`) previously returned a static list of all registered API routes for debugging purposes. With this change, the codebase is cleaner and no longer exposes this internal instrumentation endpoint.

- **Cleanup of Debugging Instrumentation:**
  * Removed the `/api/v1/_routes` endpoint and associated static route listing, which was used for debugging 404 issues on nested review routes. This reduces unnecessary code and potential exposure of internal API structure.

- **Minor Import Cleanup:**
  * Removed the unused `sort` import since it is no longer needed after deleting the route enumeration logic.…issues